### PR TITLE
Use risZuglaufId to get fahrtNr

### DIFF
--- a/parse/line.js
+++ b/parse/line.js
@@ -2,7 +2,7 @@ import slugg from 'slugg';
 
 const parseLine = (ctx, p) => {
 	const profile = ctx.profile;
-	const fahrtNr = p.verkehrsmittel?.nummer || p.transport?.number || p.train?.no || p.verkehrsmittelNummer || ((p.mitteltext || '') + ' ').split(' ')[1];
+	const fahrtNr = p.verkehrsmittel?.nummer || p.transport?.number || p.train?.no || ((p.risZuglaufId || '') + '_').split('_')[1] || p.verkehrsmittelNummer || ((p.mitteltext || '') + ' ').split(' ')[1];
 	const res = {
 		type: 'line',
 		id: slugg(p.verkehrsmittel?.langText || p.transport?.journeyDescription || p.train && p.train.category + ' ' + p.train.lineName + ' ' + p.train.no || p.langtext || p.mitteltext), // TODO terrible


### PR DESCRIPTION
fahrtNr is currently unreliable. For hafas-client it was always interpretable as int, currently it is not. For example, for the following line it does not return the correct result (`6` instead of the correct `31600`)

```
{
  administrationId: "8003S_",
  risZuglaufId: "S_31600",
  risAbfahrtId: "8003368_2025-01-10T17:21:00+01:00",
  kurztext: "S",
  mitteltext: "S 6",
  langtext: "S 6",
  zuglaufId: "2|#VN#1#ST#1736364871#PI#1#ZI#212722#TA#5#DA#100125#1S#8004948#1T#1614#LS#8003373#LT#1746#PU#81#RT#1#CA#s#ZE#6#ZB#S      6#PC#4#FR#8004948#FT#1614#TO#8003373#TT#1746#",
  nummer: 4,
  typ: "FAHRZEUG",
  abgangsDatum: "2025-01-10T17:21:00+01:00",
  ankunftsDatum: "2025-01-10T17:23:00+01:00",
  verkehrsmittelNummer: "6",
  richtung: "Köln-Worringen",
  produktGattung: "SBAHN",
  wagenreihung: true,
  ...
}
```

For dbnav, the correct `fahrtNr` always seems to be included in the `risZuglaufId`