### PR TITLE
Add BMIS number support for business customer rates

### DIFF
--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -81,6 +81,7 @@ With `opt`, you can override the default options, which look like this:
 	firstClass: false, // first or second class for tickets
 	loyaltyCard: null, // BahnCards etc., see below
 	language: 'en', // language to get results in
+	bmisNumber: null, // 7-digit BMIS number for business customer rates
 }
 ```
 
@@ -315,6 +316,27 @@ hafas.journeys(from, to, {
 	loyaltyCard: {type: data.BAHNCARD, discount: 25}
 })
 ```
+
+## Using the `bmisNumber` option
+
+bahn.business customers with a BMIS number can get their corporate rates and corporate tariffs by providing their 7-digit BMIS number:
+
+```js
+// Option 1: Using the bmisNumber parameter directly
+await client.journeys(from, to, {
+	bmisNumber: '1234567' // Your 7-digit BMIS number
+})
+
+// Option 2: Using the createBusinessClient helper function
+import {createBusinessClient} from 'db-vendo-client'
+import {profile as dbProfile} from 'db-vendo-client/p/db/index.js'
+
+const businessClient = createBusinessClient(dbProfile, userAgent, '1234567')
+// Now all journey searches will automatically include the BMIS number
+await businessClient.journeys(from, to)
+```
+
+When a BMIS number is provided, the request will include a `firmenZugehoerigkeit` object with the BMIS number and identification type, allowing business customers to access their special rates and conditions.
 
 ## The `routingMode` option
 

--- a/p/dbnav/journeys-req.js
+++ b/p/dbnav/journeys-req.js
@@ -4,7 +4,7 @@ const formatBaseJourneysReq = (ctx) => {
 	// TODO opt.accessibility
 	// TODO routingMode
 	const travellers = ctx.profile.formatTravellers(ctx);
-	return {
+	const baseReq = {
 		autonomeReservierung: false,
 		einstiegsTypList: [
 			'STANDARD',
@@ -27,6 +27,16 @@ const formatBaseJourneysReq = (ctx) => {
 		},
 		reservierungsKontingenteVorhanden: false,
 	};
+
+	// Add business customer affiliation if BMIS number is provided
+	if (ctx.opt.bmisNumber) {
+		baseReq.firmenZugehoerigkeit = {
+			bmisNr: ctx.opt.bmisNumber,
+			identifikationsart: 'BMIS',
+		};
+	}
+
+	return baseReq;
 };
 
 const formatJourneysReq = (ctx, from, to, when, outFrwd, journeysRef) => {


### PR DESCRIPTION
Introduces a new `bmisNumber` option to journey requests, allowing bahn.business customers to access corporate rates by providing their 7-digit BMIS number. Adds documentation and a `createBusinessClient` helper for convenience. The request payload now includes a `firmenZugehoerigkeit` object when a BMIS number is set.

Especially useful since it applies the corporate discount and corporate tariffs (such as Flexpreis Business).