### PR TITLE
Bumped application version for DB nav

### DIFF
--- a/p/dbnav/journeys-req.js
+++ b/p/dbnav/journeys-req.js
@@ -75,7 +75,7 @@ const formatJourneysReq = (ctx, from, to, when, outFrwd, journeysRef) => {
 	return {
 		endpoint: opt.bestprice ? profile.bestpriceEndpoint : profile.journeysEndpoint,
 		body: query,
-		headers: getHeaders('application/x.db.vendo.mob.verbindungssuche.v8+json'),
+		headers: getHeaders('application/x.db.vendo.mob.verbindungssuche.v9+json'),
 		method: 'post',
 	};
 };
@@ -92,7 +92,7 @@ const formatRefreshJourneyReq = (ctx, refreshToken) => {
 	return {
 		endpoint: opt.tickets ? profile.refreshJourneysEndpointTickets : profile.refreshJourneysEndpointPolyline,
 		body: query,
-		headers: getHeaders('application/x.db.vendo.mob.verbindungssuche.v8+json'),
+		headers: getHeaders('application/x.db.vendo.mob.verbindungssuche.v9+json'),
 		method: 'post',
 	};
 };


### PR DESCRIPTION
The dbnav endpoint seems to have bumped the minimal required version. v9 seems to be working, however I have not looked into it what the newest version is, and maybe more important, whether the data format was changed.