### PR TITLE
CI: publish to npm using OIDC tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  id-token: write # for OIDC-based publishing to npm
+
 jobs:
   build-and-push-docker:
     runs-on: ubuntu-latest
@@ -53,7 +56,9 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      # for OIDC-based publishing to npm
+      - name: setup npm v11
+        run: npm install -g npm@11
+
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}      


### PR DESCRIPTION
see also https://docs.npmjs.com/trusted-publishers

The npm side is already configured correctly.