### PR TITLE
fix: stationBoard `entries` can be nullish

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ const createClient = (profile, userAgent, opt = {}) => {
 		const {res} = await profile.request({profile, opt}, userAgent, req);
 
 		const ctx = {profile, opt, common, res};
-		let results = (res[resultsField] || res.items || res.bahnhofstafelAbfahrtPositionen || res.bahnhofstafelAnkunftPositionen || res.entries.flat())
+		let results = (res[resultsField] || res.items || res.bahnhofstafelAbfahrtPositionen || res.bahnhofstafelAnkunftPositionen || res.entries?.flat() || [])
 			.map(res => parse(ctx, res)); // TODO sort?, slice
 
 		if (!opt.includeRelatedStations) {


### PR DESCRIPTION
Station board sometimes returns `{}`, causing an error to be thrown when calling `entries.flat()`.

Should I add a test ? If yes would it go in the `.har` ?