### PR TITLE
fix db profile host, app.vendo.noncd.db.de DNS is gone

### DIFF
--- a/p/db/base.json
+++ b/p/db/base.json
@@ -1,12 +1,12 @@
 {
-	"journeysEndpoint": "https://app.vendo.noncd.db.de/mob/angebote/fahrplan",
-	"bestpriceEndpoint": "https://app.vendo.noncd.db.de/mob/angebote/tagesbestpreis",
-	"refreshJourneysEndpointTickets": "https://app.vendo.noncd.db.de/mob/angebote/recon",
-	"refreshJourneysEndpointPolyline": "https://app.vendo.noncd.db.de/mob/trip/recon",
-	"locationsEndpoint": "https://app.vendo.noncd.db.de/mob/location/search",
-	"stopEndpoint": "https://app.vendo.noncd.db.de/mob/location/details/",
-	"nearbyEndpoint": "https://app.vendo.noncd.db.de/mob/location/nearby",
-	"tripEndpoint": "https://app.vendo.noncd.db.de/mob/zuglauf/",
-	"boardEndpoint": "https://app.vendo.noncd.db.de/mob/bahnhofstafel/",
+	"journeysEndpoint": "https://app.services-bahn.de/mob/angebote/fahrplan",
+	"bestpriceEndpoint": "https://app.services-bahn.de/mob/angebote/tagesbestpreis",
+	"refreshJourneysEndpointTickets": "https://app.services-bahn.de/mob/angebote/recon",
+	"refreshJourneysEndpointPolyline": "https://app.services-bahn.de/mob/trip/recon",
+	"locationsEndpoint": "https://app.services-bahn.de/mob/location/search",
+	"stopEndpoint": "https://app.services-bahn.de/mob/location/details/",
+	"nearbyEndpoint": "https://app.services-bahn.de/mob/location/nearby",
+	"tripEndpoint": "https://app.services-bahn.de/mob/zuglauf/",
+	"boardEndpoint": "https://app.services-bahn.de/mob/bahnhofstafel/",
 	"defaultLanguage": "en"
 }

--- a/test/format/db-trip.js
+++ b/test/format/db-trip.js
@@ -17,7 +17,7 @@ const tripIdHafas = '2|#VN#1#ST#1738783727#PI#0#ZI#222242#TA#0#DA#70225#1S#80002
 const tripIdRis = '20250207-e6b2807e-bb48-39f9-89eb-8491ebc4b32c';
 
 const reqDbNavExpected = {
-	endpoint: 'https://app.vendo.noncd.db.de/mob/zuglauf/',
+	endpoint: 'https://app.services-bahn.de/mob/zuglauf/',
 	path: '2%7C%23VN%231%23ST%231738783727%23PI%230%23ZI%23222242%23TA%230%23DA%2370225%231S%238000237%231T%231317%23LS%238000261%23LT%232002%23PU%2380%23RT%231%23CA%23ICE%23ZE%231007%23ZB%23ICE%201007%23PC%230%23FR%238000237%23FT%231317%23TO%238000261%23TT%232002%23',
 	headers: {
 		'Accept': 'application/x.db.vendo.mob.zuglauf.v2+json',


### PR DESCRIPTION
The host the `db` profile was pinned to (`app.vendo.noncd.db.de`) no longer resolves — A/AAAA records are gone, so every request fails with `ENOTFOUND`. The same `/mob/...` paths still exist on `app.services-bahn.de`, which is what the `dbnav` profile already uses. Curl confirms 200 responses on all relevant endpoints there.

This also updates the hard-coded URL in `test/format/db-trip.js` so the unit tests match.

Closes #48.

Note: I'm seeing the same Akamai 403 from Node `fetch` against `app.services-bahn.de` that's already discussed in #46. That's not changed by this PR (the `dbnav` profile has been on this host for a while and exhibits the same behaviour), so I'd leave it in #46.