### PR TITLE
fix: pin ALPN to http/1.1 so node-fetch never negotiates HTTP/2

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -1,12 +1,30 @@
 import {stringify} from 'qs';
 import tls from 'tls';
+import https from 'https';
 import {Request, fetch} from 'cross-fetch';
 import {parse as parseContentType} from 'content-type';
 import {HafasError} from './errors.js';
 
 const proxyAddress = typeof process !== 'undefined' && (process.env.HTTPS_PROXY || process.env.HTTP_PROXY) || null;
 
-let getAgent = () => undefined;
+// cross-fetch uses node-fetch@2, which only speaks HTTP/1.1. Hosts like
+// app.services-bahn.de (Akamai) negotiate HTTP/2 over TLS whenever the client
+// offers `h2` via ALPN, after which node-fetch tries to parse the HTTP/2 binary
+// frames with its HTTP/1.1 parser and throws
+// `HPE_INVALID_CONSTANT` ("Expected HTTP/..."). Pin ALPN to http/1.1 so
+// the connection can never negotiate a protocol we cannot read, regardless of
+// how https.globalAgent is configured.
+// See https://github.com/public-transport/db-vendo-client/issues/53
+let defaultAgent;
+const getDefaultAgent = () => {
+	if (!defaultAgent) {
+		defaultAgent = new https.Agent({ALPNProtocols: ['http/1.1']});
+	}
+	return defaultAgent;
+};
+
+let proxyConfigured = false;
+let getAgent = () => getDefaultAgent();
 
 const ciphers = [
 	'TLS_AES_128_GCM_SHA256',
@@ -31,13 +49,15 @@ if (process.env.DB_PROFILE == 'db') {
 }
 
 const setupProxy = async () => {
-	if (proxyAddress && !getAgent()) {
+	if (proxyAddress && !proxyConfigured) {
 		const a = await import('https-proxy-agent');
 		const agent = new a.default.HttpsProxyAgent(proxyAddress, {
 			keepAlive: true,
 			keepAliveMsecs: 10 * 1000, // 10s
+			ALPNProtocols: ['http/1.1'],
 		});
 		getAgent = () => agent;
+		proxyConfigured = true;
 	}
 };
 


### PR DESCRIPTION
## Problem

`cross-fetch` uses `node-fetch@2`, which only speaks HTTP/1.1. Hosts like `app.services-bahn.de` (Akamai) negotiate HTTP/2 over TLS whenever the client advertises `h2` via ALPN. When that happens the server sends HTTP/2 binary frames and node-fetch's `llhttp` parser throws on the first bytes:

```
FetchError: ... reason: Parse Error: Expected HTTP/, RTSP/ or ICE/
errno: 'HPE_INVALID_CONSTANT', code: 'HPE_INVALID_CONSTANT'
```

Full investigation in #53.

The stock client offers only `http/1.1`, so it normally negotiates HTTP/1.1 and works. The catch is that the default path relies on the ambient `https.globalAgent`: if the host app or a proxy reconfigures `https.globalAgent` to advertise `h2`, the default request (`agent` undefined) negotiates HTTP/2 and crashes. I confirmed that exposure against the live host (see Verification).

## Change

`lib/request.js` now uses a library-owned `https.Agent` pinned to `ALPNProtocols: ['http/1.1']` for the default path, and adds the same pin to the proxy agent. node-fetch@2 cannot speak HTTP/2 anyway, so pinning can only prevent a crash, never give up a usable feature.

It deliberately does not touch caller-supplied agents (e.g. a custom `transformReq` that sets `opts.agent` for TLS fingerprinting). Those still need `['http/1.1']` in their own `ALPNProtocols`; I didn't want to mutate a caller's agent object behind their back. So this hardens the library-controlled connections and closes the `https.globalAgent` exposure. The custom-agent footgun from #53 still needs the caller to pin, unless you'd rather the library coerce it as a follow-up.

## Verification

- `npm run lint` — clean
- `npm run test-unit` — 78/78 pass
- Live against `app.services-bahn.de` from a residential IP:
  - old path (`agent` undefined) + `https.globalAgent` advertising `h2` → `HPE_INVALID_CONSTANT` (reproduces the exposure)
  - `https.Agent` pinned to `['http/1.1']` under the same hostile global → parses (HTTP 405 on a probe body)
  - `createClient(dbnav).journeys(...)` on this branch → real journeys returned (`ICE 1139`), parsed cleanly, no HPE

## Disclosure

This change was co-authored by AI (Claude Code, Opus 4.8). I reviewed and tested it before opening the PR.
