### PR TITLE
FIX: reqOptions.headers use different types.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,43 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build-and-push-bun-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Bun Docker image
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=-bun,onlatest=true
+
+      - name: Build and push Bun Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: ./Dockerfile.bun
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   build-pkg:
     runs-on: ubuntu-latest
     permissions:

--- a/Dockerfile.bun
+++ b/Dockerfile.bun
@@ -1,0 +1,25 @@
+FROM oven/bun:1-alpine
+
+LABEL org.opencontainers.image.title="db-vendo-client"
+LABEL org.opencontainers.image.description="A clean REST API wrapping around the new Deutsche Bahn API."
+LABEL org.opencontainers.image.authors="Traines <git@traines.eu>"
+LABEL org.opencontainers.image.documentation="https://github.com/public-transport/db-vendo-client"
+LABEL org.opencontainers.image.source="https://github.com/public-transport/db-vendo-client"
+LABEL org.opencontainers.image.licenses="ISC"
+
+WORKDIR /app
+
+# Add git to install git-based dependencies
+RUN apk add --no-cache git
+
+# install dependencies using package-lock.json
+COPY package.json package-lock.json ./
+RUN bun install
+
+# add source code
+COPY . .
+
+EXPOSE 3000
+ENV PORT=3000
+
+CMD ["bun", "api.js"]

--- a/lib/request.js
+++ b/lib/request.js
@@ -173,7 +173,10 @@ const request = async (ctx, userAgent, reqData) => {
 	let cType = res.headers.get('content-type');
 	if (cType) {
 		const {type} = parseContentType(cType);
-		if (type !== reqOptions.headers['Accept']) {
+		// For some reason, the reqOptions.headers object is sometimes a plain object
+		// and sometimes a Headers object (In browser env). For the latter, .get() must
+		// be used.
+		if (type !== reqOptions.headers['Accept'] && type !== reqOptions.headers.get('Accept')) {
 			throw new HafasError('invalid/unsupported response content-type: ' + cType, null, errProps);
 		}
 	}


### PR DESCRIPTION
For some reason I don't understand, `reqOptions.headers` https://github.com/public-transport/db-vendo-client/blob/814ae7a5f0f97b1a48d3647d430b650966196aef/lib/request.js#L176

Is sometimes a Headers object and not a plain object. Therefore, accessing the `Accept` header sometime fails.

I found this within chromium in the latest few versions of db-vendo-client and was not able to find any reason why it should have changed. However, it was consistent that `client.locations` and `client.journeys` return plain objects while `client.trips` yields the Headers object.

This PR fixes this by allowing both types of objects. Feel free to not merge this fix and instead find the root cause of this issue.